### PR TITLE
ci: commit yarn lock with fixed version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -861,7 +861,7 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/pixelmatch@^5.2.6":
+"@types/pixelmatch@5.2.6":
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/@types/pixelmatch/-/pixelmatch-5.2.6.tgz#fba6de304ac958495f27d85989f5c6bb7499a686"
   integrity sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==


### PR DESCRIPTION
forgot to commit the yarn lock on my latest update, this PR fixes that with a fixed version of pixelmatch